### PR TITLE
Excluído @After que estava fechando em duplicidade o driver

### DIFF
--- a/src/test/java/adiconar_carrinho.java
+++ b/src/test/java/adiconar_carrinho.java
@@ -49,11 +49,4 @@ public class adiconar_carrinho {
 
     }
 
-    @After
-    public void fechar(){
-        driver.quit();
-    }
-
-
-
 }


### PR DESCRIPTION
Excluído método da classe "adiconar_carrinho.java" que estava marcado com @After e estava fazendo o fechamento do navegador com driver.quit. Já existia previamente um método marcado com @After marcado na classe "visualizar_produtos.java" que já executava o fechamento do browser com o mesmo comando driver.quit.
Esta exclusão que fiz do método evitou a exceção de NullPointer que estava ocorrendo ao chamar duas vezes o driver.quit nos dois métodos que estavam marcados com @After.